### PR TITLE
Remove git gems installed via Bundler

### DIFF
--- a/lib/gem-empty/command.rb
+++ b/lib/gem-empty/command.rb
@@ -2,6 +2,7 @@ require 'gem-empty/specification'
 require 'rubygems/command_manager'
 require 'rubygems/uninstaller'
 require 'rubygems/version'
+require 'fileutils'
 
 class EmptyCommand < Gem::Command
   def initialize
@@ -30,6 +31,9 @@ DOC
     options = {:force => true, :executables => true }.merge(options)
     uninstaller = Gem::Uninstaller.new(nil, options)
     uninstaller.remove_all(gem_dir_specs)
+
+    # Remove any Git gems installed via bundler
+    FileUtils.rm_rf(File.join(options[:install_dir] || Gem.dir,'bundler','gems'))
 
   rescue Gem::DependencyRemovalException,
          Gem::InstallError,

--- a/test/gem-wrappers/command_test.rb
+++ b/test/gem-wrappers/command_test.rb
@@ -34,6 +34,10 @@ describe EmptyCommand do
       @ui = Gem::MockGemUi.new
       @found_rake = Gem::Specification.find_by_name('rake')
       installer = Gem::Installer.new(@found_rake.cache_file, :version => @found_rake.version, :install_dir => @test_path)
+      bundler_git_gems_path = File.join(@test_path,'bundler','gems')
+      FileUtils.mkdir_p(bundler_git_gems_path)
+      @git_gem_file = File.join(bundler_git_gems_path, 'git-test')
+      FileUtils.touch(@git_gem_file)
       use_ui @ui do
         installer.install
       end
@@ -53,6 +57,15 @@ describe EmptyCommand do
       @ui.output.must_match(
         /Removing rake\nSuccessfully uninstalled rake-/
       )
+      @ui.error.must_equal("")
+    end
+
+    it "removes git gems installed via bundler" do
+      File.exist?(@git_gem_file).must_equal(true)
+      use_ui @ui do
+        subject.execute(:install_dir => @test_path)
+      end
+      File.exist?(@git_gem_file).must_equal(false)
       @ui.error.must_equal("")
     end
 


### PR DESCRIPTION
closes #2 
This approach uses fileutils to remove the git gems installed via bundler. Using fileutils seemed like the most straight forward approach. Let me know if there's a better way to do this and I'll give it a shot.

On a side note it appears the tests don't work on 2.2 since they bank on rake being installed as a gem and rake is now part of the stdlib. I think that was moved in ruby 2.0 but they did pass on 2.0 and 2.1.